### PR TITLE
Always return a client when connecting.

### DIFF
--- a/Microsoft.Band.Portable/Microsoft.Band.Portable/BandClientManager.cs
+++ b/Microsoft.Band.Portable/Microsoft.Band.Portable/BandClientManager.cs
@@ -73,18 +73,19 @@ namespace Microsoft.Band.Portable
         {
 #if __ANDROID__
             var nativeClient = NativeBandClientManager.Instance.Create(Application.Context, info.Native);
-            if (nativeClient.IsConnected)
+
+            if (!nativeClient.IsConnected)
             {
-                throw new BandException($"Aleady connected to Band '{info.Name}'.", BandErrorType.ServiceError);
+				await nativeClient.ConnectTaskAsync();
             }
-            var result = await nativeClient.ConnectTaskAsync() == ConnectionState.Connected;
+
             return new BandClient(nativeClient);
 #elif __IOS__
-            if (info.Native.IsConnected)
+            if (!info.Native.IsConnected)
             {
-                throw new BandException($"Aleady connected to Band '{info.Native.Name}'.");
+				await NativeBandClientManager.Instance.ConnectTaskAsync(info.Native);
             }
-            await NativeBandClientManager.Instance.ConnectTaskAsync(info.Native);
+            
             return new BandClient(info.Native);
 #elif WINDOWS_PHONE_APP
             var nativeClient = await NativeBandClientManager.Instance.ConnectAsync(info.Native);


### PR DESCRIPTION
Suppose we connect to the native client successfully. Subsequently, if we do not have a reference to the client (for whatever reason -- maybe we don't hang on to it), then it's impossible to get the client back because connecting again throws an exception (we're already connected). Instead of throwing an exception if already connected, just return a new BandClient using the connected native client.
